### PR TITLE
Update with the latest version of the tutorial

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jboss.errai.demo</groupId>
             <artifactId>errai-tutorial</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>4.7.0-SNAPSHOT</version>
             <type>war</type>
         </dependency>
         


### PR DESCRIPTION
Now when you do git clone https://github.com/errai/errai-tutorial the version of the errai-tutorial is another and this does the pom is wrong.